### PR TITLE
Update landing page test

### DIFF
--- a/3dFrontend/src/App.test.js
+++ b/3dFrontend/src/App.test.js
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('displays landing page heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', {
+    name: /welcome to our 3d figures store/i,
+  });
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- simplify the app test to check the landing page heading

## Testing
- `npm test` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6853188d99c483258e7b5b0432e1d196