### PR TITLE
Remove duplicate header link

### DIFF
--- a/3dFrontend/src/Components/Header.js
+++ b/3dFrontend/src/Components/Header.js
@@ -14,12 +14,11 @@ function Header() {
         <Link to="/">YourLogo</Link>
       </div>
       <SearchBar />
-      <nav className="nav-links">
-        <Link to="/products">Products</Link>
-        <Link to="/products">Products</Link>
-        <Link to="/cart">Cart ({cartItems.length})</Link>
-        {/* Future links like Cart, Login can be added here */}
-      </nav>
+        <nav className="nav-links">
+          <Link to="/products">Products</Link>
+          <Link to="/cart">Cart ({cartItems.length})</Link>
+          {/* Future links like Cart, Login can be added here */}
+        </nav>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- cleanup nav links by removing a duplicate `Products` link

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853188b45b483259df5ea7b72ab415b