### PR TITLE
Add basic auth support

### DIFF
--- a/3dFrontend/src/App.js
+++ b/3dFrontend/src/App.js
@@ -6,6 +6,8 @@ import ProductListPage from './Pages/ProductListPage';
 import ProductDetailPage from './Pages/ProductDetailPage';
 import CartPage from './Pages/CartPage';
 import CheckoutPage from './Pages/CheckoutPage';
+import LoginPage from './Pages/LoginPage';
+import RegisterPage from './Pages/RegisterPage';
 import Header from './Components/Header';
 import Footer from './Components/Footer';
 
@@ -21,6 +23,8 @@ function App() {
           <Route path="/products/:id" element={<ProductDetailPage />} />
           <Route path="/cart" element={<CartPage />} />
           <Route path="/checkout" element={<CheckoutPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
         </Routes>
         <Footer />
       </Router>

--- a/3dFrontend/src/Components/Header.js
+++ b/3dFrontend/src/Components/Header.js
@@ -5,9 +5,11 @@ import { Link } from 'react-router-dom';
 import SearchBar from './SearchBar';
 import '../styles/Header.css';
 import { useCart } from '../context/CartContext';
+import { useAuth } from '../context/AuthContext';
 
 function Header() {
     const { cartItems } = useCart();
+    const { user, logout } = useAuth();
   return (
     <header className="header">
       <div className="logo">
@@ -17,7 +19,17 @@ function Header() {
         <nav className="nav-links">
           <Link to="/products">Products</Link>
           <Link to="/cart">Cart ({cartItems.length})</Link>
-          {/* Future links like Cart, Login can be added here */}
+          {user ? (
+            <>
+              <span className="user-greet">Hi, {user.email}</span>
+              <button onClick={logout}>Logout</button>
+            </>
+          ) : (
+            <>
+              <Link to="/login">Login</Link>
+              <Link to="/register">Register</Link>
+            </>
+          )}
         </nav>
     </header>
   );

--- a/3dFrontend/src/Pages/CheckoutPage.js
+++ b/3dFrontend/src/Pages/CheckoutPage.js
@@ -2,11 +2,12 @@
 
 import React, { useState } from "react";
 import { useCart } from "../context/CartContext";
+import { useAuth } from "../context/AuthContext";
 import PaypalCheckoutButton from "../Components/PaypalCheckoutButton";
 import "../styles/CheckoutPage.css";
 
-function CheckoutPage(props) {
-  const user = props.user || null;
+function CheckoutPage() {
+  const { user } = useAuth();
   const { cartItems } = useCart();
   const [form, setForm] = useState({
     email: user?.email || "",

--- a/3dFrontend/src/Pages/LoginPage.js
+++ b/3dFrontend/src/Pages/LoginPage.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+function LoginPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(f => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await login(form.email, form.password);
+      navigate('/');
+    } catch (err) {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email:
+          <input name="email" value={form.email} onChange={handleChange} required />
+        </label>
+        <label>
+          Password:
+          <input type="password" name="password" value={form.password} onChange={handleChange} required />
+        </label>
+        <button type="submit">Login</button>
+        {error && <div className="error">{error}</div>}
+      </form>
+      <p>
+        Don't have an account? <Link to="/register">Register</Link>
+      </p>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/3dFrontend/src/Pages/RegisterPage.js
+++ b/3dFrontend/src/Pages/RegisterPage.js
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+function RegisterPage() {
+  const { register } = useAuth();
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm(f => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await register(form.email, form.password);
+      navigate('/');
+    } catch (err) {
+      setError('Registration failed');
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <h2>Register</h2>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Email:
+          <input name="email" value={form.email} onChange={handleChange} required />
+        </label>
+        <label>
+          Password:
+          <input type="password" name="password" value={form.password} onChange={handleChange} required />
+        </label>
+        <button type="submit">Register</button>
+        {error && <div className="error">{error}</div>}
+      </form>
+      <p>
+        Already have an account? <Link to="/login">Login</Link>
+      </p>
+    </div>
+  );
+}
+
+export default RegisterPage;

--- a/3dFrontend/src/context/AuthContext.js
+++ b/3dFrontend/src/context/AuthContext.js
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import api from '../Services/api';
+
+const AuthContext = createContext();
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    const saved = localStorage.getItem('auth_user');
+    return saved ? JSON.parse(saved) : null;
+  });
+  const [token, setToken] = useState(() => localStorage.getItem('auth_token'));
+
+  // Attach token to axios
+  useEffect(() => {
+    if (token) {
+      api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+    } else {
+      delete api.defaults.headers.common['Authorization'];
+    }
+  }, [token]);
+
+  const login = async (email, password) => {
+    const res = await api.post('/auth/login/', { email, password });
+    setUser(res.data.user);
+    setToken(res.data.token);
+    localStorage.setItem('auth_user', JSON.stringify(res.data.user));
+    localStorage.setItem('auth_token', res.data.token);
+  };
+
+  const register = async (email, password) => {
+    const res = await api.post('/auth/register/', { email, password });
+    setUser(res.data.user);
+    setToken(res.data.token);
+    localStorage.setItem('auth_user', JSON.stringify(res.data.user));
+    localStorage.setItem('auth_token', res.data.token);
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem('auth_user');
+    localStorage.removeItem('auth_token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/3dFrontend/src/context/CartContext.js
+++ b/3dFrontend/src/context/CartContext.js
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useState } from "react";
 import api from "../Services/api";
+import { useAuth } from "./AuthContext";
 
 // Create context
 const CartContext = createContext();
@@ -15,7 +16,8 @@ function getInitialCart() {
   return saved ? JSON.parse(saved) : [];
 }
 
-export function CartProvider({ user, children }) {
+export function CartProvider({ children }) {
+  const { user } = useAuth();
   const [cartItems, setCartItems] = useState(getInitialCart());
 
   // Sync guest cart with localStorage

--- a/3dFrontend/src/index.js
+++ b/3dFrontend/src/index.js
@@ -4,12 +4,15 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { CartProvider } from './context/CartContext';
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <CartProvider>
-      <App />
-    </CartProvider>
+    <AuthProvider>
+      <CartProvider>
+        <App />
+      </CartProvider>
+    </AuthProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- create `AuthContext` to store JWT and user data
- add login and register pages
- read auth context in `CartProvider`
- wrap the app in `AuthProvider`
- show Login/Register or Logout in header
- add auth routes

## Testing
- `npm test` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854997be2588325ab4204d5f5c97572