### PR TITLE
Add credit card checkout UI

### DIFF
--- a/3dFrontend/src/Components/CreditCardCheckoutForm.js
+++ b/3dFrontend/src/Components/CreditCardCheckoutForm.js
@@ -1,0 +1,92 @@
+import React, { useState } from 'react';
+import api from '../Services/api';
+import { useCart } from '../context/CartContext';
+
+function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
+  const { clearCart } = useCart();
+  const [card, setCard] = useState({ name: '', number: '', expiry: '', cvc: '' });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setCard((c) => ({ ...c, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const payload = {
+        total_cost: total,
+        products: cartItems.map((i) => ({
+          product_id: i.product_id,
+          quantity: i.quantity,
+        })),
+        card,
+      };
+      if (user) {
+        payload.user_id = user.id;
+        payload.address = form.address;
+      } else {
+        payload.guest_email = form.email;
+        payload.guest_address = form.address;
+      }
+      await api.post('/payments/charge-card', payload);
+      clearCart();
+      if (onSuccess) onSuccess();
+    } catch (err) {
+      setError('Payment failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form className="credit-card-form" onSubmit={handleSubmit}>
+      <label>
+        Name on Card:
+        <input
+          name="name"
+          value={card.name}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <label>
+        Card Number:
+        <input
+          name="number"
+          value={card.number}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <label>
+        Expiry Date (MM/YY):
+        <input
+          name="expiry"
+          value={card.expiry}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <label>
+        CVC:
+        <input
+          name="cvc"
+          value={card.cvc}
+          onChange={handleChange}
+          required
+        />
+      </label>
+      <button type="submit" disabled={loading}>
+        {loading ? 'Processing...' : 'Pay Now'}
+      </button>
+      {error && <div className="error">{error}</div>}
+    </form>
+  );
+}
+
+export default CreditCardCheckoutForm;

--- a/3dFrontend/src/Pages/CheckoutPage.js
+++ b/3dFrontend/src/Pages/CheckoutPage.js
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { useCart } from "../context/CartContext";
 import PaypalCheckoutButton from "../Components/PaypalCheckoutButton";
+import CreditCardCheckoutForm from "../Components/CreditCardCheckoutForm";
 import "../styles/CheckoutPage.css";
 
 function CheckoutPage(props) {
@@ -13,6 +14,7 @@ function CheckoutPage(props) {
     address: user?.address || "",
   });
   const [status, setStatus] = useState("");
+  const [method, setMethod] = useState("paypal");
 
   const getProduct = (item) => item.product || item;
 
@@ -56,13 +58,45 @@ function CheckoutPage(props) {
           </ul>
           <p><b>Total: ${total.toFixed(2)}</b></p>
         </div>
-        <PaypalCheckoutButton
-          user={user}
-          form={form}
-          cartItems={cartItems}
-          total={total}
-          onSuccess={() => setStatus("Payment successful!")}
-        />
+        <div className="payment-method">
+          <label>
+            <input
+              type="radio"
+              name="paymentMethod"
+              value="paypal"
+              checked={method === "paypal"}
+              onChange={() => setMethod("paypal")}
+            />
+            PayPal
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="paymentMethod"
+              value="card"
+              checked={method === "card"}
+              onChange={() => setMethod("card")}
+            />
+            Credit Card
+          </label>
+        </div>
+        {method === "paypal" ? (
+          <PaypalCheckoutButton
+            user={user}
+            form={form}
+            cartItems={cartItems}
+            total={total}
+            onSuccess={() => setStatus("Payment successful!")}
+          />
+        ) : (
+          <CreditCardCheckoutForm
+            user={user}
+            form={form}
+            cartItems={cartItems}
+            total={total}
+            onSuccess={() => setStatus("Payment successful!")}
+          />
+        )
         {status && <div className="status">{status}</div>}
       </form>
     </div>

--- a/3dFrontend/src/styles/CheckoutPage.css
+++ b/3dFrontend/src/styles/CheckoutPage.css
@@ -71,3 +71,51 @@
   color: #219c55;
   text-align: center;
 }
+
+.payment-method {
+  display: flex;
+  gap: 20px;
+  margin-top: 8px;
+}
+
+.payment-method label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.credit-card-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.credit-card-form input {
+  padding: 8px;
+  border-radius: 7px;
+  border: 1px solid #ccc;
+  margin-top: 6px;
+}
+
+.credit-card-form button {
+  background: #219c55;
+  color: #fff;
+  border: none;
+  padding: 10px 0;
+  border-radius: 7px;
+  font-size: 1.08rem;
+  font-weight: bold;
+  cursor: pointer;
+  margin-top: 12px;
+  transition: background 0.2s;
+}
+
+.credit-card-form button:hover {
+  background: #17643c;
+}
+
+.credit-card-form .error {
+  color: #b00020;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Summary
- build radio-based payment selector on the checkout page
- add new `CreditCardCheckoutForm` for manual card entry
- style payment method UI and card form

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685499829fb48325a45648c8001f5e14