### PR TITLE
Adapt PayPal frontend integration

### DIFF
--- a/3dFrontend/README.md
+++ b/3dFrontend/README.md
@@ -68,3 +68,5 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+This app uses PayPal for payments. Set `REACT_APP_PAYPAL_CLIENT_ID` in a .env file for your PayPal credentials.

--- a/3dFrontend/src/App.js
+++ b/3dFrontend/src/App.js
@@ -13,10 +13,12 @@ import Footer from './Components/Footer';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
+const paypalClientId = process.env.REACT_APP_PAYPAL_CLIENT_ID || 'test';
+
 
 function App() {
   return (
-    <PayPalScriptProvider options={{ "client-id": "test" }}>
+    <PayPalScriptProvider options={{ "client-id": paypalClientId }}>
       <Router>
         <Header />
         <Routes>

--- a/3dFrontend/src/Components/PaypalCheckoutButton.js
+++ b/3dFrontend/src/Components/PaypalCheckoutButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PayPalButtons } from '@paypal/react-paypal-js';
-import api from '../Services/api';
+import { createPaypalOrder, capturePaypalOrder } from '../Services/paypal';
 import { useCart } from '../context/CartContext';
 import { toast } from 'react-toastify';
 
@@ -8,26 +8,12 @@ function PaypalCheckoutButton({ user, form, cartItems, total, onSuccess }) {
   const { clearCart } = useCart();
 
   const createOrder = () => {
-    const payload = {
-      total_cost: total,
-      products: cartItems.map(i => ({
-        product_id: i.product_id,
-        quantity: i.quantity,
-      })),
-    };
-    if (user) {
-      payload.user_id = user.id;
-      payload.address = form.address;
-    } else {
-      payload.guest_email = form.email;
-      payload.guest_address = form.address;
-    }
-    return api.post('/payments/create-paypal-order', payload)
-      .then(res => res.data.orderID);
+    return createPaypalOrder(total)
+      .then((data) => data.id);
   };
 
   const onApproveHandler = (data) => {
-    return api.post('/payments/capture-paypal-order', { orderID: data.orderID })
+    return capturePaypalOrder(data.orderID)
       .then(() => {
         clearCart();
         toast.success('Payment successful');

--- a/3dFrontend/src/Services/paypal.js
+++ b/3dFrontend/src/Services/paypal.js
@@ -1,0 +1,16 @@
+import api from './api';
+
+export function createPaypalOrder(amount, returnUrl, cancelUrl) {
+  const payload = { amount };
+  if (returnUrl) payload.return_url = returnUrl;
+  if (cancelUrl) payload.cancel_url = cancelUrl;
+  return api
+    .post('/paypal/create-order', payload)
+    .then((res) => res.data);
+}
+
+export function capturePaypalOrder(orderId) {
+  return api
+    .post('/paypal/capture-order', { order_id: orderId })
+    .then((res) => res.data);
+}

--- a/README.md
+++ b/README.md
@@ -27,5 +27,11 @@ requests. You can set this variable in a `.env` file or in your environment.
 If omitted, it defaults to `http://localhost:8000`.
    ```
 
+4. **PayPal Client ID**
+   Set `REACT_APP_PAYPAL_CLIENT_ID` in your environment with your PayPal client
+   ID. The PayPal integration falls back to the sandbox `test` ID if this
+   variable is not provided.
+
 
 The bulk of the source code (components, pages and services) lives inside the `3dFrontend/src` folder.
+


### PR DESCRIPTION
## Summary
- add PayPal service wrapper for backend API
- use new service in checkout button
- read PayPal client id from environment
- document PayPal client id env variable

## Testing
- `npm install`
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68553f7ab08883259e94ec335b903120