### PR TITLE
Implement image carousel on product detail page

### DIFF
--- a/3dFrontend/src/Components/ImageCarousel.js
+++ b/3dFrontend/src/Components/ImageCarousel.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import '../styles/ImageCarousel.css';
+
+function ImageCarousel({ images, altPrefix }) {
+  const [index, setIndex] = useState(0);
+
+  if (!images || images.length === 0) {
+    return null;
+  }
+
+  const prev = () => {
+    setIndex((index - 1 + images.length) % images.length);
+  };
+
+  const next = () => {
+    setIndex((index + 1) % images.length);
+  };
+
+  return (
+    <div className="image-carousel">
+      {images.length > 1 && (
+        <button className="prev" onClick={prev} aria-label="Previous image">
+          ‹
+        </button>
+      )}
+      <img src={images[index]} alt={`${altPrefix} ${index + 1}`} />
+      {images.length > 1 && (
+        <button className="next" onClick={next} aria-label="Next image">
+          ›
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default ImageCarousel;

--- a/3dFrontend/src/Pages/ProductDetailPage.js
+++ b/3dFrontend/src/Pages/ProductDetailPage.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import api from '../Services/api';
 import ThreeDViewer from '../Components/ThreeDViewer';
+import ImageCarousel from '../Components/ImageCarousel';
 import '../styles/ProductDetailPage.css';
 import { useCart } from '../context/CartContext';
 import ClipLoader from 'react-spinners/ClipLoader';
@@ -57,12 +58,10 @@ function ProductDetailPage() {
   return (
     <div className="product-detail-page">
       <div className="product-visual">
-        {/* Image gallery (show all) */}
+        {/* Images displayed as a carousel */}
         {images.length > 0 && (
           <div className="product-images">
-            {images.map((img, idx) => (
-              <img key={idx} src={img} alt={product.name + ' img' + idx} />
-            ))}
+            <ImageCarousel images={images} altPrefix={product.name} />
           </div>
         )}
         {/* 3D Viewer */}

--- a/3dFrontend/src/styles/ImageCarousel.css
+++ b/3dFrontend/src/styles/ImageCarousel.css
@@ -1,0 +1,33 @@
+.image-carousel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: auto;
+}
+
+.image-carousel img {
+  max-width: 100%;
+  display: block;
+}
+
+.image-carousel button {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.image-carousel button.prev {
+  left: 0.5rem;
+}
+
+.image-carousel button.next {
+  right: 0.5rem;
+}

--- a/3dFrontend/src/styles/ProductDetailPage.css
+++ b/3dFrontend/src/styles/ProductDetailPage.css
@@ -13,6 +13,11 @@
   .product-details {
     flex: 1;
   }
+
+  .product-images {
+    max-width: 100%;
+    margin-bottom: 1rem;
+  }
   
   .product-details h2 {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- display product images in a simple carousel component
- add reusable `ImageCarousel` with navigation buttons
- update styles for new carousel display

## Testing
- `npm test --silent` *(fails: No tests found related to files changed since last commit)*

------
https://chatgpt.com/codex/tasks/task_e_68619ac5dd148325adf54c1fa2f72bba