### PR TITLE
Add 404 page and fix model viewer

### DIFF
--- a/3dFrontend/src/App.js
+++ b/3dFrontend/src/App.js
@@ -8,6 +8,7 @@ import CartPage from './Pages/CartPage';
 import CheckoutPage from './Pages/CheckoutPage';
 import LoginPage from './Pages/LoginPage';
 import RegisterPage from './Pages/RegisterPage';
+import NotFoundPage from './Pages/NotFoundPage';
 import Header from './Components/Header';
 import Footer from './Components/Footer';
 import { ToastContainer } from 'react-toastify';
@@ -29,6 +30,7 @@ function App() {
           <Route path="/checkout" element={<CheckoutPage />} />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
         <Footer />
         <ToastContainer />

--- a/3dFrontend/src/Components/ThreeDViewer.js
+++ b/3dFrontend/src/Components/ThreeDViewer.js
@@ -19,8 +19,6 @@ function Model({ url }) {
 }
 
 function ThreeDViewer({ modelUrl }) {
-  // For debugging: swap modelUrl to a known working public GLB to test
-  modelUrl = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 
   if (!modelUrl) return <div style={{ color: 'gray' }}>No 3D model available.</div>;
   return (

--- a/3dFrontend/src/Pages/NotFoundPage.js
+++ b/3dFrontend/src/Pages/NotFoundPage.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function NotFoundPage() {
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <h2>Page Not Found</h2>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  );
+}
+
+export default NotFoundPage;

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This repository contains a React frontend application located in the `3dFrontend
    This will run the app in development mode at [http://localhost:3000](http://localhost:3000).
 
 3. **Configure the API URL**
-   The application expects a backend API. Update the `API_BASE_URL` constant in `src/Services/Api.js` if your backend runs on a different address:
+   The application expects a backend API. Update the `API_BASE_URL` constant in `src/Services/api.js` if your backend runs on a different address:
    ```javascript
-   // 3dFrontend/src/Services/Api.js
+   // 3dFrontend/src/Services/api.js
    const API_BASE_URL = 'http://localhost:8000';
 
    The frontend reads `REACT_APP_API_URL` to determine the base URL for API


### PR DESCRIPTION
## Summary
- add `NotFoundPage` component and fallback route
- respect the `modelUrl` prop in `ThreeDViewer`
- fix doc path references to `src/Services/api.js`

## Testing
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6861a39fa92883259c04785409e8e539