### PR TITLE
Increase product visuals size

### DIFF
--- a/3dFrontend/src/Components/ThreeDViewer.js
+++ b/3dFrontend/src/Components/ThreeDViewer.js
@@ -22,7 +22,7 @@ function ThreeDViewer({ modelUrl }) {
 
   if (!modelUrl) return <div style={{ color: 'gray' }}>No 3D model available.</div>;
   return (
-    <div className="three-d-viewer" style={{ width: "100%", height: "400px" }}>
+    <div className="three-d-viewer" style={{ width: "100%", maxWidth: "1600px", height: "1200px" }}>
       <Canvas camera={{ position: [0, 2, 10], fov: 45 }}>
         {/* Bright ambient/directional light */}
         <ambientLight intensity={1.1} />
@@ -30,7 +30,7 @@ function ThreeDViewer({ modelUrl }) {
         <Suspense fallback={<Html center><div>Loading 3D Model...</div></Html>}>
           <Model url={modelUrl} />
         </Suspense>
-        <OrbitControls makeDefault />
+        <OrbitControls makeDefault autoRotate autoRotateSpeed={1} />
         <Axes />
       </Canvas>
     </div>

--- a/3dFrontend/src/styles/ImageCarousel.css
+++ b/3dFrontend/src/styles/ImageCarousel.css
@@ -3,8 +3,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 400px;
-  height: 300px;
+  width: 800px;
+  height: 600px;
   margin: 0 auto;
 }
 

--- a/3dFrontend/src/styles/ProductDetailPage.css
+++ b/3dFrontend/src/styles/ProductDetailPage.css
@@ -15,7 +15,7 @@
   }
 
 .product-images {
-    max-width: 400px;
+    max-width: 800px;
     margin: 0 auto 1rem auto;
   }
   

--- a/3dFrontend/src/styles/ThreeDViewer.css
+++ b/3dFrontend/src/styles/ThreeDViewer.css
@@ -2,7 +2,8 @@
 
 .three-d-viewer {
   width: 100%;
-  height: 400px;
+  max-width: 1600px;
+  height: 1200px;
   background: var(--viewer-background);
   border-radius: 12px;
   overflow: hidden;
@@ -11,7 +12,7 @@
 
 @media (max-width: 600px) {
   .three-d-viewer {
-    height: 300px;
+    height: 600px;
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge image carousel and container widths
- enlarge product image container
- enlarge Three.js viewer to show bigger models
- spin models slowly with auto-rotation

## Testing
- `npm test --silent` *(fails: SyntaxError in axios import)*

------
https://chatgpt.com/codex/tasks/task_e_6861b07fb14883259d01e506360d2a5d