### PR TITLE
Add media caching for images and models

### DIFF
--- a/3dFrontend/README.md
+++ b/3dFrontend/README.md
@@ -70,3 +70,9 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
 
 This app uses PayPal for payments. Set `REACT_APP_PAYPAL_CLIENT_ID` in a .env file for your PayPal credentials.
+
+### Media caching
+
+Images and 3D models fetched from the API are cached in IndexedDB for 24 hours.
+Cached blobs are reused when available which reduces network requests. The
+cache is automatically invalidated after one day.

--- a/3dFrontend/package-lock.json
+++ b/3dFrontend/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.7.7",
+        "idb-keyval": "^6.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.5.0",
@@ -10625,6 +10626,12 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",

--- a/3dFrontend/package.json
+++ b/3dFrontend/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.7.7",
+    "idb-keyval": "^6.2.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.5.0",
@@ -30,6 +31,11 @@
     "extends": [
       "react-app",
       "react-app/jest"
+    ]
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(axios)/)"
     ]
   },
   "browserslist": {

--- a/3dFrontend/src/App.test.js
+++ b/3dFrontend/src/App.test.js
@@ -1,5 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
+import { CartProvider } from './context/CartContext';
+
+// Mock CSS from react-toastify to avoid Jest errors
+jest.mock('react-toastify/dist/ReactToastify.css', () => {});
 
 // Mock the ThreeDViewer to avoid WebGL issues in jsdom
 jest.mock('./Components/ThreeDViewer', () => () => (
@@ -7,7 +12,13 @@ jest.mock('./Components/ThreeDViewer', () => () => (
 ));
 
 test('displays landing page heading', () => {
-  render(<App />);
+  render(
+    <AuthProvider>
+      <CartProvider>
+        <App />
+      </CartProvider>
+    </AuthProvider>
+  );
   const heading = screen.getByRole('heading', {
     name: /welcome to our 3d figures store/i,
   });

--- a/3dFrontend/src/Components/ProductCard.js
+++ b/3dFrontend/src/Components/ProductCard.js
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import '../styles/ProductCard.css';
-import api from '../Services/api';
+import { getMediaBlob } from '../Services/mediaCache';
 
 function ProductCard({ product }) {
   const [imageUrl, setImageUrl] = useState(null);
@@ -13,9 +13,9 @@ function ProductCard({ product }) {
       // Find first image-type media
       const imageMedia = product.media.find(m => m.media_type === 'image');
       if (imageMedia) {
-        // Fetch image as blob, create object URL
-        api.get(`/media/${imageMedia.id}`, { responseType: 'blob' })
-          .then(res => setImageUrl(URL.createObjectURL(res.data)))
+        // Fetch image with caching
+        getMediaBlob(imageMedia.id)
+          .then(blob => setImageUrl(URL.createObjectURL(blob)))
           .catch(() => setImageUrl('/placeholder.jpg'));
       } else {
         setImageUrl('/placeholder.jpg');

--- a/3dFrontend/src/Pages/ProductDetailPage.js
+++ b/3dFrontend/src/Pages/ProductDetailPage.js
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import api from '../Services/api';
+import { getMediaBlob } from '../Services/mediaCache';
 import ThreeDViewer from '../Components/ThreeDViewer';
 import ImageCarousel from '../Components/ImageCarousel';
 import '../styles/ProductDetailPage.css';
@@ -30,12 +31,12 @@ function ProductDetailPage() {
         if (response.data.media && response.data.media.length > 0) {
           for (const media of response.data.media) {
             if (media.media_type === "image") {
-              const imgRes = await api.get(`/media/${media.id}`, { responseType: 'blob' });
-              imgs.push(URL.createObjectURL(imgRes.data));
+              const blob = await getMediaBlob(media.id);
+              imgs.push(URL.createObjectURL(blob));
             }
             if (media.media_type === "model" && !modelBlobUrl) {
-              const modelRes = await api.get(`/media/${media.id}`, { responseType: 'blob' });
-              modelBlobUrl = URL.createObjectURL(modelRes.data);
+              const blob = await getMediaBlob(media.id);
+              modelBlobUrl = URL.createObjectURL(blob);
             }
           }
         }

--- a/3dFrontend/src/Services/mediaCache.js
+++ b/3dFrontend/src/Services/mediaCache.js
@@ -1,0 +1,50 @@
+import { get, set, del } from 'idb-keyval';
+import api from './api';
+
+// Cache duration in milliseconds (24 hours)
+const CACHE_DURATION = 24 * 60 * 60 * 1000;
+
+async function fetchMediaBlob(id) {
+  const response = await api.get(`/media/${id}`, { responseType: 'blob' });
+  return response.data;
+}
+
+export async function getMediaBlob(id) {
+  const key = `media-${id}`;
+  try {
+    const cached = await get(key);
+    if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+      return cached.blob;
+    }
+    if (cached) {
+      await del(key);
+    }
+  } catch (err) {
+    console.warn('Media cache read failed', err);
+  }
+
+  const blob = await fetchMediaBlob(id);
+  try {
+    await set(key, { blob, timestamp: Date.now() });
+  } catch (err) {
+    console.warn('Media cache write failed', err);
+  }
+  return blob;
+}
+
+export async function clearMediaCache() {
+  // Not used currently, but provided for manual invalidation if needed
+  // Iterate through keys and remove expired entries
+  const now = Date.now();
+  const keys = await (await import('idb-keyval')).keys();
+  await Promise.all(
+    keys
+      .filter((k) => typeof k === 'string' && k.startsWith('media-'))
+      .map(async (k) => {
+        const item = await get(k);
+        if (!item || now - item.timestamp >= CACHE_DURATION) {
+          await del(k);
+        }
+      })
+  );
+}


### PR DESCRIPTION
## Summary
- add new `mediaCache` service using IndexedDB
- cache images in `ProductCard` and `ProductDetailPage`
- mock CSS imports and wrap `App` in providers for tests
- document the media caching behaviour
- install `idb-keyval` dependency and adjust Jest config

## Testing
- `npm test --silent <<'EOF'
q
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686da7f32ba08325bcf82a8c149016e0