### PR TITLE
Handle 3D model load errors

### DIFF
--- a/3dFrontend/src/Components/ThreeDViewer.js
+++ b/3dFrontend/src/Components/ThreeDViewer.js
@@ -4,6 +4,28 @@ import React, { Suspense } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, useGLTF, Html } from '@react-three/drei';
 import '../styles/ThreeDViewer.css';
+class ModelErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    console.warn("ThreeDViewer: failed to load model", this.props.modelUrl, error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
 
 // Helper for debugging: axes at origin
 function Axes() {
@@ -27,9 +49,11 @@ function ThreeDViewer({ modelUrl }) {
         {/* Bright ambient/directional light */}
         <ambientLight intensity={1.1} />
         <directionalLight intensity={2} position={[0, 10, 10]} />
-        <Suspense fallback={<Html center><div>Loading 3D Model...</div></Html>}>
-          <Model url={modelUrl} />
-        </Suspense>
+          <ModelErrorBoundary modelUrl={modelUrl} fallback={<Html center><div className="error">Failed to load 3D model.</div></Html>}>
+            <Suspense fallback={<Html center><div>Loading 3D Model...</div></Html>}>
+              <Model url={modelUrl} />
+            </Suspense>
+          </ModelErrorBoundary>
         <OrbitControls makeDefault autoRotate autoRotateSpeed={1} />
         <Axes />
       </Canvas>


### PR DESCRIPTION
## Summary
- add a `ModelErrorBoundary` to `ThreeDViewer`
- show an error message in the canvas if `useGLTF` fails
- warn in the console when the model can't load

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dae0b006c8325a5f56b5aa13dcf04