### PR TITLE
Add extra 3D showcases

### DIFF
--- a/3dFrontend/src/Components/ThreeDViewer.js
+++ b/3dFrontend/src/Components/ThreeDViewer.js
@@ -40,11 +40,17 @@ function Model({ url }) {
   return <primitive object={scene} />;
 }
 
-function ThreeDViewer({ modelUrl }) {
+function ThreeDViewer({ modelUrl, style = {} }) {
 
   if (!modelUrl) return <div style={{ color: 'gray' }}>No 3D model available.</div>;
+  const viewerStyle = {
+    width: "100%",
+    maxWidth: "1600px",
+    height: "1200px",
+    ...style,
+  };
   return (
-    <div className="three-d-viewer" style={{ width: "100%", maxWidth: "1600px", height: "1200px" }}>
+    <div className="three-d-viewer" style={viewerStyle}>
       <Canvas camera={{ position: [0, 2, 10], fov: 45 }}>
         {/* Bright ambient/directional light */}
         <ambientLight intensity={1.1} />

--- a/3dFrontend/src/Pages/LandingPage.js
+++ b/3dFrontend/src/Pages/LandingPage.js
@@ -20,6 +20,16 @@ function LandingPage() {
       <section className="featured-model">
         <h2>Featured 3D Model</h2>
         <ThreeDViewer modelUrl={modelUrl} />
+        <div className="additional-showcases">
+          <ThreeDViewer
+            modelUrl={modelUrl}
+            style={{ maxWidth: "200px", height: "167px" }}
+          />
+          <ThreeDViewer
+            modelUrl={modelUrl}
+            style={{ maxWidth: "200px", height: "167px" }}
+          />
+        </div>
         <p>Experience our latest creation from every angle.</p>
         <Link to="/products" className="cta-button">
           Explore Models

--- a/3dFrontend/src/styles/LandingPage.css
+++ b/3dFrontend/src/styles/LandingPage.css
@@ -31,5 +31,16 @@
 .featured-model .three-d-viewer {
   height: 500px;
   max-width: 600px;
-  margin: 0 auto;
-}  
+  margin: 0 auto;}
+
+.additional-showcases {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.additional-showcases .three-d-viewer {
+  height: 167px;
+  max-width: 200px;
+}


### PR DESCRIPTION
## Summary
- allow custom style overrides in `ThreeDViewer`
- show two smaller 3D viewer showcases on the landing page
- style the additional showcases

## Testing
- `npm test -- --runTestsByPath src/App.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ef9a1353083259139389413ed455d