### PR TITLE
Fix landing page showcases

### DIFF
--- a/3dFrontend/src/Pages/LandingPage.js
+++ b/3dFrontend/src/Pages/LandingPage.js
@@ -18,16 +18,19 @@ function LandingPage() {
         </Link>
       </div>
       <section className="featured-model">
-        <h2>Featured 3D Model</h2>
-        <ThreeDViewer modelUrl={modelUrl} />
-        <div className="additional-showcases">
+        <h2>Featured 3D Models</h2>
+        <div className="showcases">
           <ThreeDViewer
             modelUrl={modelUrl}
-            style={{ maxWidth: "200px", height: "167px" }}
+            style={{ maxWidth: "400px", height: "333px" }}
           />
           <ThreeDViewer
             modelUrl={modelUrl}
-            style={{ maxWidth: "200px", height: "167px" }}
+            style={{ maxWidth: "400px", height: "333px" }}
+          />
+          <ThreeDViewer
+            modelUrl={modelUrl}
+            style={{ maxWidth: "400px", height: "333px" }}
           />
         </div>
         <p>Experience our latest creation from every angle.</p>

--- a/3dFrontend/src/styles/LandingPage.css
+++ b/3dFrontend/src/styles/LandingPage.css
@@ -28,19 +28,15 @@
   margin: 1rem 0;
 }
 
-.featured-model .three-d-viewer {
-  height: 500px;
-  max-width: 600px;
-  margin: 0 auto;}
-
-.additional-showcases {
+/* Containers for the row of showcases displayed on the landing page */
+.showcases {
   display: flex;
   justify-content: center;
   gap: 1rem;
   margin-top: 1rem;
 }
 
-.additional-showcases .three-d-viewer {
-  height: 167px;
-  max-width: 200px;
+.showcases .three-d-viewer {
+  height: 333px;
+  max-width: 400px;
 }


### PR DESCRIPTION
## Summary
- display all three showcases at the same size
- style landing page showcases using a single flex container

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686efbfc62888325a32029628b16e64e