### PR TITLE
Update landing page showcases and add category nav

### DIFF
--- a/3dFrontend/src/App.js
+++ b/3dFrontend/src/App.js
@@ -11,6 +11,8 @@ import RegisterPage from './Pages/RegisterPage';
 import NotFoundPage from './Pages/NotFoundPage';
 import Header from './Components/Header';
 import Footer from './Components/Footer';
+import CategorySidebar from './Components/CategorySidebar';
+import './styles/CategoryNav.css';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -22,6 +24,9 @@ function App() {
     <PayPalScriptProvider options={{ "client-id": paypalClientId }}>
       <Router>
         <Header />
+        <div className="category-nav">
+          <CategorySidebar />
+        </div>
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="/products" element={<ProductListPage />} />

--- a/3dFrontend/src/Components/ThreeDViewer.js
+++ b/3dFrontend/src/Components/ThreeDViewer.js
@@ -27,10 +27,6 @@ class ModelErrorBoundary extends React.Component {
 }
 
 
-// Helper for debugging: axes at origin
-function Axes() {
-  return <axesHelper args={[5]} />;
-}
 
 function Model({ url }) {
   // Log loading
@@ -60,8 +56,7 @@ function ThreeDViewer({ modelUrl, style = {} }) {
               <Model url={modelUrl} />
             </Suspense>
           </ModelErrorBoundary>
-        <OrbitControls makeDefault autoRotate autoRotateSpeed={1} />
-        <Axes />
+        <OrbitControls makeDefault autoRotate autoRotateSpeed={0.5} />
       </Canvas>
     </div>
   );

--- a/3dFrontend/src/Pages/LandingPage.js
+++ b/3dFrontend/src/Pages/LandingPage.js
@@ -22,15 +22,15 @@ function LandingPage() {
         <div className="showcases">
           <ThreeDViewer
             modelUrl={modelUrl}
-            style={{ maxWidth: "400px", height: "333px" }}
+            style={{ maxWidth: "600px", height: "500px" }}
           />
           <ThreeDViewer
             modelUrl={modelUrl}
-            style={{ maxWidth: "400px", height: "333px" }}
+            style={{ maxWidth: "600px", height: "500px" }}
           />
           <ThreeDViewer
             modelUrl={modelUrl}
-            style={{ maxWidth: "400px", height: "333px" }}
+            style={{ maxWidth: "600px", height: "500px" }}
           />
         </div>
         <p>Experience our latest creation from every angle.</p>

--- a/3dFrontend/src/Pages/ProductListPage.js
+++ b/3dFrontend/src/Pages/ProductListPage.js
@@ -3,7 +3,6 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import api from '../Services/api';
-import CategorySidebar from '../Components/CategorySidebar';
 import ProductGrid from '../Components/ProductGrid';
 import '../styles/ProductListPage.css';
 import ClipLoader from 'react-spinners/ClipLoader';
@@ -34,7 +33,6 @@ function ProductListPage() {
 
   return (
     <div className="product-list-page">
-      <CategorySidebar />
       <div className="product-list-content">
         {loading ? <ClipLoader /> : <ProductGrid products={products} />}
       </div>

--- a/3dFrontend/src/styles/CategoryNav.css
+++ b/3dFrontend/src/styles/CategoryNav.css
@@ -1,0 +1,27 @@
+.category-nav {
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.category-nav .category-sidebar {
+  width: auto;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+
+.category-nav .category-sidebar h3 {
+  margin-right: 1rem;
+}
+
+.category-nav .category-sidebar ul {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.category-nav .category-sidebar li {
+  margin: 0;
+}

--- a/3dFrontend/src/styles/LandingPage.css
+++ b/3dFrontend/src/styles/LandingPage.css
@@ -32,11 +32,11 @@
 .showcases {
   display: flex;
   justify-content: center;
-  gap: 1rem;
+  gap: 5px;
   margin-top: 1rem;
 }
 
 .showcases .three-d-viewer {
-  height: 333px;
-  max-width: 400px;
+  height: 500px;
+  max-width: 600px;
 }

--- a/3dFrontend/src/styles/ProductListPage.css
+++ b/3dFrontend/src/styles/ProductListPage.css
@@ -1,23 +1,15 @@
 /* src/pages/ProductListPage.css */
 
 .product-list-page {
-    display: flex;
-  }
+  padding: 1rem;
+}
 
   .product-list-content {
-    flex: 1;
     padding: 1rem;
   }
 
   @media (max-width: 768px) {
     .product-list-page {
-      flex-direction: column;
+      padding: 0.5rem;
     }
-
-    /* make sidebar full width on small screens */
-    .product-list-page .category-sidebar {
-      width: 100%;
-      margin-bottom: 1rem;
-    }
-  }
-  
+  }  


### PR DESCRIPTION
## Summary
- scale up 3D showcases on the landing page
- tighten spacing between showcases
- slow down showcase rotation and remove axes
- add global category navigation bar
- clean up product list layout

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686efdc7723c832585fc6c3247c62ea2