### PR TITLE
Add label and focus styles to search input

### DIFF
--- a/3dFrontend/src/Components/SearchBar.js
+++ b/3dFrontend/src/Components/SearchBar.js
@@ -15,7 +15,9 @@ function SearchBar() {
 
   return (
     <form className="search-bar" onSubmit={handleSubmit}>
+      <label htmlFor="searchInput">Search products:</label>
       <input
+        id="searchInput"
         type="text"
         placeholder="Search products..."
         value={query}

--- a/3dFrontend/src/styles/SearchBar.css
+++ b/3dFrontend/src/styles/SearchBar.css
@@ -23,4 +23,10 @@
   .search-bar button:hover {
     background: var(--color-accent-hover);
   }
+
+  .search-bar input:focus,
+  .search-bar button:focus {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+  }
   


### PR DESCRIPTION
## Summary
- label search input for accessibility
- keep focus outline for keyboard users

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686fc897be4483258ab77a5a5e06b4de