### PR TITLE
Refactor category list for accessibility

### DIFF
--- a/3dFrontend/src/Components/CategorySidebar.js
+++ b/3dFrontend/src/Components/CategorySidebar.js
@@ -33,19 +33,32 @@ function CategorySidebar() {
     <aside className="category-sidebar">
       <h3>Categories</h3>
       <ul>
-        <li
-          className={!selectedCategory ? 'active' : ''}
-          onClick={() => handleCategoryClick(null)}
-        >
-          All
+        <li className={!selectedCategory ? 'active' : ''}>
+          <button
+            type="button"
+            onClick={() => handleCategoryClick(null)}
+            onKeyDown={(e) =>
+              (e.key === 'Enter' || e.key === ' ') && handleCategoryClick(null)
+            }
+          >
+            All
+          </button>
         </li>
         {categories.map((category) => (
           <li
             key={category.id}
             className={selectedCategory === category.id.toString() ? 'active' : ''}
-            onClick={() => handleCategoryClick(category.id)}
           >
-            {category.name}
+            <button
+              type="button"
+              onClick={() => handleCategoryClick(category.id)}
+              onKeyDown={(e) =>
+                (e.key === 'Enter' || e.key === ' ') &&
+                handleCategoryClick(category.id)
+              }
+            >
+              {category.name}
+            </button>
           </li>
         ))}
       </ul>

--- a/3dFrontend/src/styles/CategorySidebar.css
+++ b/3dFrontend/src/styles/CategorySidebar.css
@@ -15,9 +15,17 @@
     padding: 0;
   }
   
-  .category-sidebar li {
+.category-sidebar li {
     margin-bottom: 0.5rem;
+  }
+
+.category-sidebar li button {
+    background: none;
+    border: none;
+    padding: 0;
     cursor: pointer;
+    width: 100%;
+    text-align: left;
   }
   
 .category-sidebar li.active {


### PR DESCRIPTION
## Summary
- use buttons for CategorySidebar interactive elements
- support keyboard selection with Enter or Space
- style sidebar buttons

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686fce8f010883258d19ae54d586c6a9