### PR TITLE
Add accessible labels for cart quantities

### DIFF
--- a/3dFrontend/src/Pages/CartPage.js
+++ b/3dFrontend/src/Pages/CartPage.js
@@ -34,10 +34,15 @@ function CartPage() {
                 <tr key={item.product_id}>
                   <td>{prod.name}</td>
                   <td>
+                    <label htmlFor={`qty-${item.product_id}`} className="sr-only">
+                      {`Quantity for ${prod.name}`}
+                    </label>
                     <input
+                      id={`qty-${item.product_id}`}
                       type="number"
                       min="1"
                       value={item.quantity}
+                      aria-label={`Quantity for ${prod.name}`}
                       onChange={e => updateCartItem(item.product_id, parseInt(e.target.value))}
                       style={{ width: 50 }}
                     />

--- a/3dFrontend/src/index.css
+++ b/3dFrontend/src/index.css
@@ -43,3 +43,16 @@ textarea:focus {
   outline-offset: 2px;
 }
 
+/* Hide elements visually but keep them accessible to screen readers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+


### PR DESCRIPTION
## Summary
- add screen-reader-only class in global styles
- label cart quantity inputs with product-specific text

## Testing
- `npm test --silent` *(fails: React warning output)*

------
https://chatgpt.com/codex/tasks/task_e_686fd10a97f08325887034165f0f7cff