### PR TITLE
Improve 3D viewer accessibility

### DIFF
--- a/3dFrontend/src/Components/ThreeDViewer.js
+++ b/3dFrontend/src/Components/ThreeDViewer.js
@@ -36,7 +36,7 @@ function Model({ url }) {
   return <primitive object={scene} />;
 }
 
-function ThreeDViewer({ modelUrl, style = {} }) {
+function ThreeDViewer({ modelUrl, style = {}, alt }) {
 
   if (!modelUrl) return <div style={{ color: 'gray' }}>No 3D model available.</div>;
   const viewerStyle = {
@@ -45,8 +45,9 @@ function ThreeDViewer({ modelUrl, style = {} }) {
     height: "1200px",
     ...style,
   };
+  const ariaLabel = alt || '3D model viewer';
   return (
-    <div className="three-d-viewer" style={viewerStyle}>
+    <div className="three-d-viewer" style={viewerStyle} role="img" aria-label={ariaLabel}>
       <Canvas camera={{ position: [0, 2, 10], fov: 45 }}>
         {/* Bright ambient/directional light */}
         <ambientLight intensity={1.1} />
@@ -58,6 +59,7 @@ function ThreeDViewer({ modelUrl, style = {} }) {
           </ModelErrorBoundary>
         <OrbitControls makeDefault autoRotate autoRotateSpeed={0.5} />
       </Canvas>
+      {alt && <span className="visually-hidden">{alt}</span>}
     </div>
   );
 }

--- a/3dFrontend/src/Pages/LandingPage.js
+++ b/3dFrontend/src/Pages/LandingPage.js
@@ -23,14 +23,17 @@ function LandingPage() {
           <ThreeDViewer
             modelUrl={modelUrl}
             style={{ maxWidth: "600px", height: "500px" }}
+            alt="Featured 3D model"
           />
           <ThreeDViewer
             modelUrl={modelUrl}
             style={{ maxWidth: "600px", height: "500px" }}
+            alt="Featured 3D model"
           />
           <ThreeDViewer
             modelUrl={modelUrl}
             style={{ maxWidth: "600px", height: "500px" }}
+            alt="Featured 3D model"
           />
         </div>
         <p>Experience our latest creation from every angle.</p>

--- a/3dFrontend/src/Pages/ProductDetailPage.js
+++ b/3dFrontend/src/Pages/ProductDetailPage.js
@@ -68,7 +68,7 @@ function ProductDetailPage() {
         {/* 3D Viewer */}
         {modelUrl && (
           <div className="product-3dviewer">
-            <ThreeDViewer modelUrl={modelUrl} />
+            <ThreeDViewer modelUrl={modelUrl} alt={`3D model of ${product.name}`} />
           </div>
         )}
       </div>

--- a/3dFrontend/src/styles/ThreeDViewer.css
+++ b/3dFrontend/src/styles/ThreeDViewer.css
@@ -10,6 +10,18 @@
   margin: 0 auto 20px auto;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (max-width: 600px) {
   .three-d-viewer {
     height: 600px;


### PR DESCRIPTION
## Summary
- allow passing alt text to `ThreeDViewer`
- expose model view as a role="img" with aria-label
- provide visually hidden description style
- pass alt text from product and landing pages

## Testing
- `npm test --silent -- --runTestsByPath src/App.test.js` *(fails: react-scripts not found)*
- `npm install --silent` *(fails: no output, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_686fd10b5f18832582a69c0bbe6556f7