### PR TITLE
Add lazy loading for product images

### DIFF
--- a/3dFrontend/src/Components/ImageCarousel.js
+++ b/3dFrontend/src/Components/ImageCarousel.js
@@ -23,7 +23,7 @@ function ImageCarousel({ images, altPrefix }) {
           ‹
         </button>
       )}
-      <img src={images[index]} alt={`${altPrefix} ${index + 1}`} />
+      <img loading="lazy" src={images[index]} alt={`${altPrefix} ${index + 1}`} />
       {images.length > 1 && (
         <button className="next" onClick={next} aria-label="Next image">
           ›

--- a/3dFrontend/src/Components/ProductCard.js
+++ b/3dFrontend/src/Components/ProductCard.js
@@ -31,7 +31,7 @@ function ProductCard({ product }) {
   return (
     <div className="product-card">
       <Link to={`/products/${product.id}`}>
-        <img src={imageUrl || '/placeholder.jpg'} alt={product.name} />
+        <img loading="lazy" src={imageUrl || '/placeholder.jpg'} alt={product.name} />
         <h4>{product.name}</h4>
       </Link>
       <p>${parseFloat(product.selling_cost).toFixed(2)}</p>


### PR DESCRIPTION
## Summary
- update ProductCard and ImageCarousel components to use native image lazy loading

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686fe8cd3a6c8325a750809676e58b17