### PR TITLE
Add Helmet for SEO metadata

### DIFF
--- a/3dFrontend/package-lock.json
+++ b/3dFrontend/package-lock.json
@@ -18,6 +18,7 @@
         "idb-keyval": "^6.2.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^1.3.0",
         "react-router-dom": "^6.27.0",
         "react-scripts": "5.0.1",
         "react-spinners": "^0.17.0",
@@ -10788,6 +10789,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -16801,6 +16811,29 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "license": "MIT"
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.3.0.tgz",
+      "integrity": "sha512-9jZ57/dAn9t3q6hneQS0wukqC2ENOBgMNVEhb/ZG9ZSxUetzVIw4iAmEU38IaVg3QGYauQPhSeUTuIUtFglWpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.2.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -17837,6 +17870,12 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/3dFrontend/package.json
+++ b/3dFrontend/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
     "react-scripts": "5.0.1",
+    "react-helmet-async": "^1.3.0",
     "three": "^0.169.0",
     "web-vitals": "^2.1.4"
   },

--- a/3dFrontend/public/index.html
+++ b/3dFrontend/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Shop high-quality 3D printed figures and models."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>3D Figures Store</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/3dFrontend/src/App.test.js
+++ b/3dFrontend/src/App.test.js
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import { CartProvider } from './context/CartContext';
+import { HelmetProvider } from 'react-helmet-async';
 
 // Mock CSS from react-toastify to avoid Jest errors
 jest.mock('react-toastify/dist/ReactToastify.css', () => {});
@@ -13,11 +14,13 @@ jest.mock('./Components/ThreeDViewer', () => () => (
 
 test('displays landing page heading', () => {
   render(
-    <AuthProvider>
-      <CartProvider>
-        <App />
-      </CartProvider>
-    </AuthProvider>
+    <HelmetProvider>
+      <AuthProvider>
+        <CartProvider>
+          <App />
+        </CartProvider>
+      </AuthProvider>
+    </HelmetProvider>
   );
   const heading = screen.getByRole('heading', {
     name: /welcome to our 3d figures store/i,

--- a/3dFrontend/src/Pages/CartPage.js
+++ b/3dFrontend/src/Pages/CartPage.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { Helmet } from 'react-helmet-async';
 import { useCart } from "../context/CartContext";
 import "../styles/CartPage.css";
 
@@ -17,6 +18,10 @@ function CartPage() {
 
   return (
     <div className="cart-page">
+      <Helmet>
+        <title>Your Cart - 3D Figures Store</title>
+        <meta name="description" content="View and manage items in your shopping cart." />
+      </Helmet>
       <h2>Your Cart</h2>
       {cartItems.length === 0 ? (
         <p>Your cart is empty.</p>

--- a/3dFrontend/src/Pages/CheckoutPage.js
+++ b/3dFrontend/src/Pages/CheckoutPage.js
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { useCart } from "../context/CartContext";
 import { useAuth } from "../context/AuthContext";
+import { Helmet } from 'react-helmet-async';
 import PaypalCheckoutButton from "../Components/PaypalCheckoutButton";
 import CreditCardCheckoutForm from "../Components/CreditCardCheckoutForm";
 import "../styles/CheckoutPage.css";
@@ -27,6 +28,10 @@ function CheckoutPage() {
 
   return (
     <div className="checkout-page">
+      <Helmet>
+        <title>Checkout - 3D Figures Store</title>
+        <meta name="description" content="Complete your purchase securely." />
+      </Helmet>
       <h2>Checkout</h2>
       <form>
         {!user && (

--- a/3dFrontend/src/Pages/LandingPage.js
+++ b/3dFrontend/src/Pages/LandingPage.js
@@ -1,6 +1,7 @@
 // src/pages/LandingPage.js
 
 import React from 'react';
+import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import ThreeDViewer from '../Components/ThreeDViewer';
 import '../styles/LandingPage.css';
@@ -10,6 +11,13 @@ function LandingPage() {
     "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
   return (
     <div className="landing-page">
+      <Helmet>
+        <title>Home - 3D Figures Store</title>
+        <meta
+          name="description"
+          content="Discover our collection of amazing 3D printed figures."
+        />
+      </Helmet>
       <div className="hero">
         <h1>Welcome to Our 3D Figures Store</h1>
         <p>Discover our collection of amazing 3D printed figures.</p>

--- a/3dFrontend/src/Pages/LoginPage.js
+++ b/3dFrontend/src/Pages/LoginPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import { useAuth } from '../context/AuthContext';
 import '../styles/AuthPage.css';
 
@@ -26,6 +27,10 @@ function LoginPage() {
 
   return (
     <div className="auth-page">
+      <Helmet>
+        <title>Login - 3D Figures Store</title>
+        <meta name="description" content="Access your account to manage orders and purchases." />
+      </Helmet>
       <h2>Login</h2>
       <form onSubmit={handleSubmit}>
         <label>

--- a/3dFrontend/src/Pages/NotFoundPage.js
+++ b/3dFrontend/src/Pages/NotFoundPage.js
@@ -1,8 +1,13 @@
 import React from 'react';
+import { Helmet } from 'react-helmet-async';
 
 function NotFoundPage() {
   return (
     <div style={{ padding: '2rem', textAlign: 'center' }}>
+      <Helmet>
+        <title>404 - Page Not Found - 3D Figures Store</title>
+        <meta name="description" content="The page you are looking for does not exist." />
+      </Helmet>
       <h2>Page Not Found</h2>
       <p>The page you are looking for does not exist.</p>
     </div>

--- a/3dFrontend/src/Pages/ProductDetailPage.js
+++ b/3dFrontend/src/Pages/ProductDetailPage.js
@@ -1,6 +1,7 @@
 // src/pages/ProductDetailPage.js
 
 import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import api from '../Services/api';
 import { getMediaBlob } from '../Services/mediaCache';
@@ -58,6 +59,13 @@ function ProductDetailPage() {
 
   return (
     <div className="product-detail-page">
+      <Helmet>
+        <title>{product ? `${product.name} - 3D Figures Store` : 'Product Details - 3D Figures Store'}</title>
+        <meta
+          name="description"
+          content={product ? `Purchase ${product.name} and explore its features in detail.` : 'Detailed view of our product.'}
+        />
+      </Helmet>
       <div className="product-visual">
         {/* Images displayed as a carousel */}
         {images.length > 0 && (

--- a/3dFrontend/src/Pages/ProductListPage.js
+++ b/3dFrontend/src/Pages/ProductListPage.js
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import api from '../Services/api';
 import ProductGrid from '../Components/ProductGrid';
 import '../styles/ProductListPage.css';
@@ -33,6 +34,13 @@ function ProductListPage() {
 
   return (
     <div className="product-list-page">
+      <Helmet>
+        <title>Products - 3D Figures Store</title>
+        <meta
+          name="description"
+          content="Browse our selection of 3D printed figures."
+        />
+      </Helmet>
       <div className="product-list-content">
         {loading ? <ClipLoader /> : <ProductGrid products={products} />}
       </div>

--- a/3dFrontend/src/Pages/RegisterPage.js
+++ b/3dFrontend/src/Pages/RegisterPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
 import { useAuth } from '../context/AuthContext';
 import '../styles/AuthPage.css';
 
@@ -26,6 +27,10 @@ function RegisterPage() {
 
   return (
     <div className="auth-page">
+      <Helmet>
+        <title>Register - 3D Figures Store</title>
+        <meta name="description" content="Create an account to purchase 3D figures." />
+      </Helmet>
       <h2>Register</h2>
       <form onSubmit={handleSubmit}>
         <label>

--- a/3dFrontend/src/index.js
+++ b/3dFrontend/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
 import './index.css';
 import './theme.css';
 import App from './App';
@@ -9,11 +10,13 @@ import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AuthProvider>
-      <CartProvider>
-        <App />
-      </CartProvider>
-    </AuthProvider>
+    <HelmetProvider>
+      <AuthProvider>
+        <CartProvider>
+          <App />
+        </CartProvider>
+      </AuthProvider>
+    </HelmetProvider>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Summary
- add `react-helmet-async`
- provide HelmetProvider in `index.js`
- set default title and meta description for pages
- update tests for Helmet provider
- set default metadata in `public/index.html`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686fe8c7e9f08325b064ef2d5ad25f59