### PR TITLE
Add sitemap generator and canonical tags

### DIFF
--- a/3dFrontend/package.json
+++ b/3dFrontend/package.json
@@ -25,7 +25,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "generate:sitemap": "node scripts/generate-sitemap.js"
   },
   "eslintConfig": {
     "extends": [

--- a/3dFrontend/public/sitemap.xml
+++ b/3dFrontend/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>http://localhost:3000</loc></url>
+  <url><loc>http://localhost:3000/products</loc></url>
+  <url><loc>http://localhost:3000/cart</loc></url>
+  <url><loc>http://localhost:3000/checkout</loc></url>
+  <url><loc>http://localhost:3000/login</loc></url>
+  <url><loc>http://localhost:3000/register</loc></url>
+</urlset>

--- a/3dFrontend/scripts/generate-sitemap.js
+++ b/3dFrontend/scripts/generate-sitemap.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+// Basic script to generate sitemap.xml from the app's route definitions
+
+const appFile = path.join(__dirname, '../src/App.js');
+const appContent = fs.readFileSync(appFile, 'utf8');
+
+// Regex to extract path="..." in <Route path="..." ...>
+const routeRegex = /<Route\s+path="([^"]+)"/g;
+const routes = [];
+let match;
+while ((match = routeRegex.exec(appContent)) !== null) {
+  const route = match[1];
+  if (!route.includes(':') && route !== '*') {
+    routes.push(route);
+  }
+}
+
+// Ensure unique routes
+const uniqueRoutes = Array.from(new Set(routes));
+
+const baseUrl = process.env.SITE_URL || 'http://localhost:3000';
+const urls = uniqueRoutes
+  .map((r) => {
+    const loc = r === '/' ? baseUrl : baseUrl + r;
+    return `  <url><loc>${loc}</loc></url>`;
+  })
+  .join('\n');
+
+const xml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>`;
+
+const outPath = path.join(__dirname, '../public/sitemap.xml');
+fs.writeFileSync(outPath, xml);
+console.log(`Generated sitemap with ${uniqueRoutes.length} routes at ${outPath}`);

--- a/3dFrontend/src/Pages/CartPage.js
+++ b/3dFrontend/src/Pages/CartPage.js
@@ -21,6 +21,7 @@ function CartPage() {
       <Helmet>
         <title>Your Cart - 3D Figures Store</title>
         <meta name="description" content="View and manage items in your shopping cart." />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <h2>Your Cart</h2>
       {cartItems.length === 0 ? (

--- a/3dFrontend/src/Pages/CheckoutPage.js
+++ b/3dFrontend/src/Pages/CheckoutPage.js
@@ -31,6 +31,7 @@ function CheckoutPage() {
       <Helmet>
         <title>Checkout - 3D Figures Store</title>
         <meta name="description" content="Complete your purchase securely." />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <h2>Checkout</h2>
       <form>

--- a/3dFrontend/src/Pages/LandingPage.js
+++ b/3dFrontend/src/Pages/LandingPage.js
@@ -17,6 +17,7 @@ function LandingPage() {
           name="description"
           content="Discover our collection of amazing 3D printed figures."
         />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <div className="hero">
         <h1>Welcome to Our 3D Figures Store</h1>

--- a/3dFrontend/src/Pages/LoginPage.js
+++ b/3dFrontend/src/Pages/LoginPage.js
@@ -30,6 +30,7 @@ function LoginPage() {
       <Helmet>
         <title>Login - 3D Figures Store</title>
         <meta name="description" content="Access your account to manage orders and purchases." />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <h2>Login</h2>
       <form onSubmit={handleSubmit}>

--- a/3dFrontend/src/Pages/NotFoundPage.js
+++ b/3dFrontend/src/Pages/NotFoundPage.js
@@ -7,6 +7,7 @@ function NotFoundPage() {
       <Helmet>
         <title>404 - Page Not Found - 3D Figures Store</title>
         <meta name="description" content="The page you are looking for does not exist." />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <h2>Page Not Found</h2>
       <p>The page you are looking for does not exist.</p>

--- a/3dFrontend/src/Pages/ProductDetailPage.js
+++ b/3dFrontend/src/Pages/ProductDetailPage.js
@@ -65,6 +65,7 @@ function ProductDetailPage() {
           name="description"
           content={product ? `Purchase ${product.name} and explore its features in detail.` : 'Detailed view of our product.'}
         />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <div className="product-visual">
         {/* Images displayed as a carousel */}

--- a/3dFrontend/src/Pages/ProductListPage.js
+++ b/3dFrontend/src/Pages/ProductListPage.js
@@ -40,6 +40,7 @@ function ProductListPage() {
           name="description"
           content="Browse our selection of 3D printed figures."
         />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <div className="product-list-content">
         {loading ? <ClipLoader /> : <ProductGrid products={products} />}

--- a/3dFrontend/src/Pages/RegisterPage.js
+++ b/3dFrontend/src/Pages/RegisterPage.js
@@ -30,6 +30,7 @@ function RegisterPage() {
       <Helmet>
         <title>Register - 3D Figures Store</title>
         <meta name="description" content="Create an account to purchase 3D figures." />
+        <link rel="canonical" href={window.location.href} />
       </Helmet>
       <h2>Register</h2>
       <form onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary
- generate a sitemap based on routes
- add a canonical link tag on every page using Helmet
- expose new `generate:sitemap` npm script

## Testing
- `CI=true npm test --silent`
- `npm run generate:sitemap --silent`


------
https://chatgpt.com/codex/tasks/task_e_686feeb8b8cc832590f196be3c1dd423