### PR TITLE
Improve navigation markup

### DIFF
--- a/3dFrontend/src/Components/Header.js
+++ b/3dFrontend/src/Components/Header.js
@@ -16,20 +16,34 @@ function Header() {
         <Link to="/">YourLogo</Link>
       </div>
       <SearchBar />
-        <nav className="nav-links">
-          <Link to="/products">Products</Link>
-          <Link to="/cart">Cart ({cartItems.length})</Link>
-          {user ? (
-            <>
-              <span className="user-greet">Hi, {user.email}</span>
-              <button onClick={logout}>Logout</button>
-            </>
-          ) : (
-            <>
-              <Link to="/login">Login</Link>
-              <Link to="/register">Register</Link>
-            </>
-          )}
+        <nav className="nav-links" aria-label="Main navigation">
+          <ul>
+            <li>
+              <Link to="/products">Products</Link>
+            </li>
+            <li>
+              <Link to="/cart">Cart ({cartItems.length})</Link>
+            </li>
+            {user ? (
+              <>
+                <li className="user-greet">
+                  <span>Hi, {user.email}</span>
+                </li>
+                <li>
+                  <button onClick={logout}>Logout</button>
+                </li>
+              </>
+            ) : (
+              <>
+                <li>
+                  <Link to="/login">Login</Link>
+                </li>
+                <li>
+                  <Link to="/register">Register</Link>
+                </li>
+              </>
+            )}
+          </ul>
         </nav>
     </header>
   );


### PR DESCRIPTION
## Summary
- add `aria-label` to nav element
- wrap navigation links in a semantic `ul`/`li` list

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686ff0276f14832598ccf3ebe3347acc