### PR TITLE
Add preconnect links for external resources

### DIFF
--- a/3dFrontend/public/index.html
+++ b/3dFrontend/public/index.html
@@ -9,6 +9,9 @@
       name="description"
       content="Shop high-quality 3D printed figures and models."
     />
+    <!-- Preconnect to external domains used frequently -->
+    <link rel="preconnect" href="https://www.paypal.com" />
+    <link rel="preconnect" href="https://modelviewer.dev" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
@@ -38,6 +41,8 @@
 
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
+      Consider adding the "async" or "defer" attribute when loading heavy
+      third-party scripts to improve performance.
     -->
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add preconnect hints for paypal and modelviewer domains
- note async/defer guidance for heavy scripts

## Testing
- `npm install --silent` *(fails: react-scripts not found)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ff027b208832592af72dfec37a4ca