### PR TITLE
Add hamburger nav and clean search bar

### DIFF
--- a/3dFrontend/src/Components/Header.js
+++ b/3dFrontend/src/Components/Header.js
@@ -1,6 +1,6 @@
 // src/components/header.js
 
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import SearchBar from './SearchBar';
 import '../styles/Header.css';
@@ -10,19 +10,28 @@ import { useAuth } from '../context/AuthContext';
 function Header() {
     const { cartItems } = useCart();
     const { user, logout } = useAuth();
+    const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <header className="header">
       <div className="logo">
         <Link to="/">YourLogo</Link>
       </div>
       <SearchBar />
-        <nav className="nav-links" aria-label="Main navigation">
+      <button
+        className="menu-toggle"
+        onClick={() => setMenuOpen((prev) => !prev)}
+        aria-label="Toggle navigation menu"
+      >
+        \u2630
+      </button>
+        <nav className={`nav-links${menuOpen ? ' open' : ''}`} aria-label="Main navigation">
           <ul>
             <li>
-              <Link to="/products">Products</Link>
+              <Link to="/products" onClick={() => setMenuOpen(false)}>Products</Link>
             </li>
             <li>
-              <Link to="/cart">Cart ({cartItems.length})</Link>
+              <Link to="/cart" onClick={() => setMenuOpen(false)}>Cart ({cartItems.length})</Link>
             </li>
             {user ? (
               <>
@@ -30,16 +39,16 @@ function Header() {
                   <span>Hi, {user.email}</span>
                 </li>
                 <li>
-                  <button onClick={logout}>Logout</button>
+                  <button onClick={() => { setMenuOpen(false); logout(); }}>Logout</button>
                 </li>
               </>
             ) : (
               <>
                 <li>
-                  <Link to="/login">Login</Link>
+                    <Link to="/login" onClick={() => setMenuOpen(false)}>Login</Link>
                 </li>
                 <li>
-                  <Link to="/register">Register</Link>
+                    <Link to="/register" onClick={() => setMenuOpen(false)}>Register</Link>
                 </li>
               </>
             )}

--- a/3dFrontend/src/Components/SearchBar.js
+++ b/3dFrontend/src/Components/SearchBar.js
@@ -14,15 +14,14 @@ function SearchBar() {
   };
 
   return (
-    <form className="search-bar" onSubmit={handleSubmit}>
-      <label htmlFor="searchInput">Search products:</label>
-      <input
-        id="searchInput"
-        type="text"
-        placeholder="Search products..."
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
+      <form className="search-bar" onSubmit={handleSubmit}>
+        <input
+          id="searchInput"
+          type="text"
+          placeholder="Search..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
       <button type="submit">Search</button>
     </form>
   );

--- a/3dFrontend/src/styles/Header.css
+++ b/3dFrontend/src/styles/Header.css
@@ -28,4 +28,44 @@
 .nav-links a:hover {
   color: var(--color-primary);
 }
+
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  margin-left: 1rem;
+  cursor: pointer;
+}
+
+.nav-links ul {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (max-width: 768px) {
+  .menu-toggle {
+    display: block;
+  }
+  .nav-links {
+    display: none;
+    position: absolute;
+    right: 1rem;
+    top: 100%;
+    background: var(--color-background);
+    border: 1px solid var(--color-border);
+    padding: 1rem;
+  }
+  .nav-links.open {
+    display: block;
+  }
+  .nav-links ul {
+    flex-direction: column;
+  }
+  .nav-links a {
+    margin: 0.5rem 0;
+  }
+}
   


### PR DESCRIPTION
## Summary
- remove the search label and simplify placeholder
- redesign header with a hamburger menu for Products/Cart/Login/Register
- add responsive styles for the new menu

## Testing
- `npm install`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ff6720de08325a58e2dc4fd108f5d