### PR TITLE
Add ThemeContext with dark mode toggle

### DIFF
--- a/3dFrontend/README.md
+++ b/3dFrontend/README.md
@@ -76,3 +76,8 @@ This app uses PayPal for payments. Set `REACT_APP_PAYPAL_CLIENT_ID` in a .env fi
 Images and 3D models fetched from the API are cached in IndexedDB for 24 hours.
 Cached blobs are reused when available which reduces network requests. The
 cache is automatically invalidated after one day.
+
+### Theme toggle
+
+Click the **Dark Mode** button in the header to switch between light and dark
+themes. The preference is saved in `localStorage` and persists across visits.

--- a/3dFrontend/src/App.test.js
+++ b/3dFrontend/src/App.test.js
@@ -3,6 +3,7 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import { CartProvider } from './context/CartContext';
 import { HelmetProvider } from 'react-helmet-async';
+import { ThemeProvider } from './context/ThemeContext';
 
 // Mock CSS from react-toastify to avoid Jest errors
 jest.mock('react-toastify/dist/ReactToastify.css', () => {});
@@ -15,11 +16,13 @@ jest.mock('./Components/ThreeDViewer', () => () => (
 test('displays landing page heading', () => {
   render(
     <HelmetProvider>
-      <AuthProvider>
-        <CartProvider>
-          <App />
-        </CartProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <CartProvider>
+            <App />
+          </CartProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </HelmetProvider>
   );
   const heading = screen.getByRole('heading', {

--- a/3dFrontend/src/Components/Header.js
+++ b/3dFrontend/src/Components/Header.js
@@ -6,11 +6,13 @@ import SearchBar from './SearchBar';
 import '../styles/Header.css';
 import { useCart } from '../context/CartContext';
 import { useAuth } from '../context/AuthContext';
+import { useTheme } from '../context/ThemeContext';
 
 function Header() {
     const { cartItems } = useCart();
     const { user, logout } = useAuth();
     const [menuOpen, setMenuOpen] = useState(false);
+    const { toggleTheme, theme } = useTheme();
 
   return (
     <header className="header">
@@ -54,7 +56,13 @@ function Header() {
             )}
           </ul>
         </nav>
-    </header>
+        <button
+          className="theme-toggle"
+          onClick={() => { toggleTheme(); setMenuOpen(false); }}
+        >
+          {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+        </button>
+      </header>
   );
 }
 

--- a/3dFrontend/src/context/ThemeContext.js
+++ b/3dFrontend/src/context/ThemeContext.js
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    const saved = localStorage.getItem('app_theme');
+    return saved ? saved : 'light';
+  });
+
+  useEffect(() => {
+    localStorage.setItem('app_theme', theme);
+    if (theme === 'dark') {
+      document.body.classList.add('dark-theme');
+    } else {
+      document.body.classList.remove('dark-theme');
+    }
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/3dFrontend/src/index.js
+++ b/3dFrontend/src/index.js
@@ -8,15 +8,18 @@ import reportWebVitals from './reportWebVitals';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import { CartProvider } from './context/CartContext';
 import { AuthProvider } from './context/AuthContext';
+import { ThemeProvider } from './context/ThemeContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HelmetProvider>
-      <AuthProvider>
-        <CartProvider>
-          <App />
-        </CartProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <CartProvider>
+            <App />
+          </CartProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </HelmetProvider>
   </React.StrictMode>
 );

--- a/3dFrontend/src/styles/Header.css
+++ b/3dFrontend/src/styles/Header.css
@@ -68,4 +68,17 @@
     margin: 0.5rem 0;
   }
 }
+
+.theme-toggle {
+  margin-left: 1rem;
+  border: 1px solid var(--color-border);
+  background: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--color-text);
+}
+.theme-toggle:hover {
+  background-color: var(--color-surface);
+}
   


### PR DESCRIPTION
## Summary
- create `ThemeContext` with persistent state and body class updates
- wrap app with `ThemeProvider`
- add dark mode toggle button in header and corresponding styles
- document theme toggle usage in README
- update test setup to include the new provider

## Testing
- `npm install`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6870220b97808325b4d9ca7476ad0715