### PR TITLE
Improve theme toggle styling

### DIFF
--- a/3dFrontend/src/Components/Header.js
+++ b/3dFrontend/src/Components/Header.js
@@ -20,13 +20,14 @@ function Header() {
         <Link to="/">YourLogo</Link>
       </div>
       <SearchBar />
-      <button
-        className="menu-toggle"
-        onClick={() => setMenuOpen((prev) => !prev)}
-        aria-label="Toggle navigation menu"
-      >
-        \u2630
-      </button>
+      <div className="header-controls">
+        <button
+          className="menu-toggle"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-label="Toggle navigation menu"
+        >
+          \u2630
+        </button>
         <nav className={`nav-links${menuOpen ? ' open' : ''}`} aria-label="Main navigation">
           <ul>
             <li>
@@ -62,6 +63,7 @@ function Header() {
         >
           {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
         </button>
+      </div>
       </header>
   );
 }

--- a/3dFrontend/src/styles/Header.css
+++ b/3dFrontend/src/styles/Header.css
@@ -12,6 +12,11 @@
   border-bottom: 1px solid var(--color-border);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
 }
+
+.header-controls {
+  display: flex;
+  align-items: center;
+}
   
   .logo a {
     font-size: 1.5rem;
@@ -49,6 +54,9 @@
   .menu-toggle {
     display: block;
   }
+  .theme-toggle {
+    margin-left: 0.5rem;
+  }
   .nav-links {
     display: none;
     position: absolute;
@@ -71,12 +79,13 @@
 
 .theme-toggle {
   margin-left: 1rem;
-  border: 1px solid var(--color-border);
-  background: none;
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
-  cursor: pointer;
+  border: 1px solid var(--color-border);
+  background: var(--color-background);
   color: var(--color-text);
+  cursor: pointer;
+  transition: background-color 0.15s;
 }
 .theme-toggle:hover {
   background-color: var(--color-surface);


### PR DESCRIPTION
## Summary
- group navigation controls and theme toggle in `Header`
- style `.theme-toggle` button with background and transition
- adjust mobile spacing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687023a4031c83259ab0f8ad7e8295f4