### PR TITLE
feat: add Spanish language support

### DIFF
--- a/3dFrontend/src/App.test.js
+++ b/3dFrontend/src/App.test.js
@@ -4,6 +4,7 @@ import { AuthProvider } from './context/AuthContext';
 import { CartProvider } from './context/CartContext';
 import { HelmetProvider } from 'react-helmet-async';
 import { ThemeProvider } from './context/ThemeContext';
+import { LanguageProvider } from './context/LanguageContext';
 
 // Mock CSS from react-toastify to avoid Jest errors
 jest.mock('react-toastify/dist/ReactToastify.css', () => {});
@@ -16,13 +17,15 @@ jest.mock('./Components/ThreeDViewer', () => () => (
 test('displays landing page heading', () => {
   render(
     <HelmetProvider>
-      <ThemeProvider>
-        <AuthProvider>
-          <CartProvider>
-            <App />
-          </CartProvider>
-        </AuthProvider>
-      </ThemeProvider>
+      <LanguageProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            <CartProvider>
+              <App />
+            </CartProvider>
+          </AuthProvider>
+        </ThemeProvider>
+      </LanguageProvider>
     </HelmetProvider>
   );
   const heading = screen.getByRole('heading', {

--- a/3dFrontend/src/Components/CategorySidebar.js
+++ b/3dFrontend/src/Components/CategorySidebar.js
@@ -4,11 +4,13 @@ import React, { useEffect, useState } from 'react';
 import api from '../Services/api';
 import '../styles/CategorySidebar.css';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useLanguage } from '../context/LanguageContext';
 
 function CategorySidebar() {
   const [categories, setCategories] = useState([]);
   const navigate = useNavigate();
   const location = useLocation();
+  const { t } = useLanguage();
 
   const params = new URLSearchParams(location.search);
   const selectedCategory = params.get('category');
@@ -31,7 +33,7 @@ function CategorySidebar() {
 
   return (
     <aside className="category-sidebar">
-      <h3>Categories</h3>
+      <h3>{t('categories')}</h3>
       <ul>
         <li className={!selectedCategory ? 'active' : ''}>
           <button
@@ -41,7 +43,7 @@ function CategorySidebar() {
               (e.key === 'Enter' || e.key === ' ') && handleCategoryClick(null)
             }
           >
-            All
+            {t('all')}
           </button>
         </li>
         {categories.map((category) => (

--- a/3dFrontend/src/Components/CreditCardCheckoutForm.js
+++ b/3dFrontend/src/Components/CreditCardCheckoutForm.js
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 import api from '../Services/api';
 import { useCart } from '../context/CartContext';
+import { useLanguage } from '../context/LanguageContext';
 
 function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
   const { clearCart } = useCart();
   const [card, setCard] = useState({ name: '', number: '', expiry: '', cvc: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const { t } = useLanguage();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -37,7 +39,7 @@ function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
       clearCart();
       if (onSuccess) onSuccess();
     } catch (err) {
-      setError('Payment failed. Please try again.');
+      setError(t('paymentFailed'));
     } finally {
       setLoading(false);
     }
@@ -46,7 +48,7 @@ function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
   return (
     <form className="credit-card-form" onSubmit={handleSubmit}>
       <label>
-        Name on Card:
+        {t('nameOnCard')}:
         <input
           name="name"
           value={card.name}
@@ -55,7 +57,7 @@ function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
         />
       </label>
       <label>
-        Card Number:
+        {t('cardNumber')}:
         <input
           name="number"
           value={card.number}
@@ -64,7 +66,7 @@ function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
         />
       </label>
       <label>
-        Expiry Date (MM/YY):
+        {t('expiryDate')}:
         <input
           name="expiry"
           value={card.expiry}
@@ -73,7 +75,7 @@ function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
         />
       </label>
       <label>
-        CVC:
+        {t('cvc')}:
         <input
           name="cvc"
           value={card.cvc}
@@ -82,7 +84,7 @@ function CreditCardCheckoutForm({ user, form, cartItems, total, onSuccess }) {
         />
       </label>
       <button type="submit" disabled={loading}>
-        {loading ? 'Processing...' : 'Pay Now'}
+        {loading ? t('processing') : t('payNow')}
       </button>
       {error && <div className="error">{error}</div>}
     </form>

--- a/3dFrontend/src/Components/Header.js
+++ b/3dFrontend/src/Components/Header.js
@@ -7,12 +7,14 @@ import '../styles/Header.css';
 import { useCart } from '../context/CartContext';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
+import { useLanguage } from '../context/LanguageContext';
 
 function Header() {
     const { cartItems } = useCart();
     const { user, logout } = useAuth();
     const [menuOpen, setMenuOpen] = useState(false);
     const { toggleTheme, theme } = useTheme();
+    const { t, language, setLanguage } = useLanguage();
 
   return (
     <header className="header">
@@ -31,37 +33,45 @@ function Header() {
         <nav className={`nav-links${menuOpen ? ' open' : ''}`} aria-label="Main navigation">
           <ul>
             <li>
-              <Link to="/products" onClick={() => setMenuOpen(false)}>Products</Link>
+              <Link to="/products" onClick={() => setMenuOpen(false)}>{t('products')}</Link>
             </li>
             <li>
-              <Link to="/cart" onClick={() => setMenuOpen(false)}>Cart ({cartItems.length})</Link>
+              <Link to="/cart" onClick={() => setMenuOpen(false)}>{`${t('cart')} (${cartItems.length})`}</Link>
             </li>
             {user ? (
               <>
                 <li className="user-greet">
-                  <span>Hi, {user.email}</span>
+                  <span>{t('hi')}, {user.email}</span>
                 </li>
                 <li>
-                  <button onClick={() => { setMenuOpen(false); logout(); }}>Logout</button>
+                  <button onClick={() => { setMenuOpen(false); logout(); }}>{t('logout')}</button>
                 </li>
               </>
             ) : (
               <>
                 <li>
-                    <Link to="/login" onClick={() => setMenuOpen(false)}>Login</Link>
+                    <Link to="/login" onClick={() => setMenuOpen(false)}>{t('login')}</Link>
                 </li>
                 <li>
-                    <Link to="/register" onClick={() => setMenuOpen(false)}>Register</Link>
+                    <Link to="/register" onClick={() => setMenuOpen(false)}>{t('register')}</Link>
                 </li>
               </>
             )}
           </ul>
         </nav>
+        <select
+          className="language-select"
+          value={language}
+          onChange={(e) => { setLanguage(e.target.value); setMenuOpen(false); }}
+        >
+          <option value="en">EN</option>
+          <option value="es">ES</option>
+        </select>
         <button
           className="theme-toggle"
           onClick={() => { toggleTheme(); setMenuOpen(false); }}
         >
-          {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+          {theme === 'dark' ? t('lightMode') : t('darkMode')}
         </button>
       </div>
       </header>

--- a/3dFrontend/src/Components/SearchBar.js
+++ b/3dFrontend/src/Components/SearchBar.js
@@ -3,10 +3,12 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/SearchBar.css';
+import { useLanguage } from '../context/LanguageContext';
 
 function SearchBar() {
   const [query, setQuery] = useState('');
   const navigate = useNavigate();
+  const { t } = useLanguage();
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -18,11 +20,11 @@ function SearchBar() {
         <input
           id="searchInput"
           type="text"
-          placeholder="Search..."
+          placeholder={t('searchPlaceholder')}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
-      <button type="submit">Search</button>
+      <button type="submit">{t('search')}</button>
     </form>
   );
 }

--- a/3dFrontend/src/Pages/CartPage.js
+++ b/3dFrontend/src/Pages/CartPage.js
@@ -5,10 +5,12 @@ import { Link, useNavigate } from "react-router-dom";
 import { Helmet } from 'react-helmet-async';
 import { useCart } from "../context/CartContext";
 import "../styles/CartPage.css";
+import { useLanguage } from '../context/LanguageContext';
 
 function CartPage() {
   const { cartItems, updateCartItem, removeCartItem } = useCart();
   const navigate = useNavigate();
+  const { t } = useLanguage();
 
   const getProduct = (item) => item.product || item; // fallback for user/guest
 
@@ -23,14 +25,14 @@ function CartPage() {
         <meta name="description" content="View and manage items in your shopping cart." />
         <link rel="canonical" href={window.location.href} />
       </Helmet>
-      <h2>Your Cart</h2>
+      <h2>{t('yourCart')}</h2>
       {cartItems.length === 0 ? (
-        <p>Your cart is empty.</p>
+        <p>{t('cartEmpty')}</p>
       ) : (
         <table>
           <thead>
             <tr>
-              <th>Product</th><th>Qty</th><th>Unit Price</th><th>Subtotal</th><th></th>
+              <th>{t('product')}</th><th>{t('qty')}</th><th>{t('unitPrice')}</th><th>{t('subtotal')}</th><th></th>
             </tr>
           </thead>
           <tbody>
@@ -56,7 +58,7 @@ function CartPage() {
                   <td>${parseFloat(prod.selling_cost).toFixed(2)}</td>
                   <td>${(prod.selling_cost * item.quantity).toFixed(2)}</td>
                   <td>
-                    <button onClick={() => removeCartItem(item.product_id)}>Remove</button>
+                    <button onClick={() => removeCartItem(item.product_id)}>{t('remove')}</button>
                   </td>
                 </tr>
               );
@@ -65,12 +67,12 @@ function CartPage() {
         </table>
       )}
       <div className="cart-summary">
-        <p>Total: <b>${total.toFixed(2)}</b></p>
+        <p>{t('total')}: <b>${total.toFixed(2)}</b></p>
         {cartItems.length > 0 && (
-          <button onClick={() => navigate("/checkout")}>Proceed to Checkout</button>
+          <button onClick={() => navigate("/checkout")}>{t('proceedCheckout')}</button>
         )}
       </div>
-      <Link to="/products">Continue Shopping</Link>
+      <Link to="/products">{t('continueShopping')}</Link>
     </div>
   );
 }

--- a/3dFrontend/src/Pages/CheckoutPage.js
+++ b/3dFrontend/src/Pages/CheckoutPage.js
@@ -7,6 +7,7 @@ import { Helmet } from 'react-helmet-async';
 import PaypalCheckoutButton from "../Components/PaypalCheckoutButton";
 import CreditCardCheckoutForm from "../Components/CreditCardCheckoutForm";
 import "../styles/CheckoutPage.css";
+import { useLanguage } from '../context/LanguageContext';
 
 function CheckoutPage() {
   const { user } = useAuth();
@@ -17,6 +18,7 @@ function CheckoutPage() {
   });
   const [status, setStatus] = useState("");
   const [method, setMethod] = useState("paypal");
+  const { t } = useLanguage();
 
   const getProduct = (item) => item.product || item;
 
@@ -33,26 +35,26 @@ function CheckoutPage() {
         <meta name="description" content="Complete your purchase securely." />
         <link rel="canonical" href={window.location.href} />
       </Helmet>
-      <h2>Checkout</h2>
+      <h2>{t('checkout')}</h2>
       <form>
         {!user && (
           <>
             <label>
-              Email: <input name="email" value={form.email} onChange={handleChange} required />
+              {t('email')}: <input name="email" value={form.email} onChange={handleChange} required />
             </label>
             <label>
-              Address: <input name="address" value={form.address} onChange={handleChange} required />
+              {t('address')}: <input name="address" value={form.address} onChange={handleChange} required />
             </label>
           </>
         )}
         {user && (
           <>
-            <p>Email: <b>{form.email}</b></p>
-            <p>Address: <input name="address" value={form.address} onChange={handleChange} required /></p>
+            <p>{t('email')}: <b>{form.email}</b></p>
+            <p>{t('address')}: <input name="address" value={form.address} onChange={handleChange} required /></p>
           </>
         )}
         <div className="order-summary">
-          <h3>Order Summary</h3>
+          <h3>{t('orderSummary')}</h3>
           <ul>
             {cartItems.map((item) => {
               const prod = getProduct(item);
@@ -63,7 +65,7 @@ function CheckoutPage() {
               );
             })}
           </ul>
-          <p><b>Total: ${total.toFixed(2)}</b></p>
+          <p><b>{t('total')}: ${total.toFixed(2)}</b></p>
         </div>
         <div className="payment-method">
           <label>
@@ -74,7 +76,7 @@ function CheckoutPage() {
               checked={method === "paypal"}
               onChange={() => setMethod("paypal")}
             />
-            PayPal
+            {t('paypal')}
           </label>
           <label>
             <input
@@ -84,7 +86,7 @@ function CheckoutPage() {
               checked={method === "card"}
               onChange={() => setMethod("card")}
             />
-            Credit Card
+            {t('creditCard')}
           </label>
         </div>
         {method === "paypal" ? (
@@ -93,7 +95,7 @@ function CheckoutPage() {
             form={form}
             cartItems={cartItems}
             total={total}
-            onSuccess={() => setStatus("Payment successful!")}
+            onSuccess={() => setStatus(t('paymentSuccess'))}
           />
         ) : (
           <CreditCardCheckoutForm
@@ -101,7 +103,7 @@ function CheckoutPage() {
             form={form}
             cartItems={cartItems}
             total={total}
-            onSuccess={() => setStatus("Payment successful!")}
+            onSuccess={() => setStatus(t('paymentSuccess'))}
           />
         )}
         {status && <div className="status">{status}</div>}

--- a/3dFrontend/src/Pages/LandingPage.js
+++ b/3dFrontend/src/Pages/LandingPage.js
@@ -5,29 +5,31 @@ import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import ThreeDViewer from '../Components/ThreeDViewer';
 import '../styles/LandingPage.css';
+import { useLanguage } from '../context/LanguageContext';
 
 function LandingPage() {
   const modelUrl =
     "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+  const { t } = useLanguage();
   return (
     <div className="landing-page">
       <Helmet>
         <title>Home - 3D Figures Store</title>
         <meta
           name="description"
-          content="Discover our collection of amazing 3D printed figures."
+          content={t('discover')}
         />
         <link rel="canonical" href={window.location.href} />
       </Helmet>
       <div className="hero">
-        <h1>Welcome to Our 3D Figures Store</h1>
-        <p>Discover our collection of amazing 3D printed figures.</p>
+        <h1>{t('welcome')}</h1>
+        <p>{t('discover')}</p>
         <Link to="/products" className="cta-button">
-          Shop Now
+          {t('shopNow')}
         </Link>
       </div>
       <section className="featured-model">
-        <h2>Featured 3D Models</h2>
+        <h2>{t('featuredModels')}</h2>
         <div className="showcases">
           <ThreeDViewer
             modelUrl={modelUrl}
@@ -45,9 +47,9 @@ function LandingPage() {
             alt="Featured 3D model"
           />
         </div>
-        <p>Experience our latest creation from every angle.</p>
+        <p>{t('experience')}</p>
         <Link to="/products" className="cta-button">
-          Explore Models
+          {t('exploreModels')}
         </Link>
       </section>
     </div>

--- a/3dFrontend/src/Pages/LoginPage.js
+++ b/3dFrontend/src/Pages/LoginPage.js
@@ -3,12 +3,14 @@ import { useNavigate, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { useAuth } from '../context/AuthContext';
 import '../styles/AuthPage.css';
+import { useLanguage } from '../context/LanguageContext';
 
 function LoginPage() {
   const { login } = useAuth();
   const navigate = useNavigate();
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
+  const { t } = useLanguage();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -21,7 +23,7 @@ function LoginPage() {
       await login(form.email, form.password);
       navigate('/');
     } catch (err) {
-      setError('Login failed');
+      setError(t('loginFailed'));
     }
   };
 
@@ -32,21 +34,21 @@ function LoginPage() {
         <meta name="description" content="Access your account to manage orders and purchases." />
         <link rel="canonical" href={window.location.href} />
       </Helmet>
-      <h2>Login</h2>
+      <h2>{t('login')}</h2>
       <form onSubmit={handleSubmit}>
         <label>
-          Email:
+          {t('email')}:
           <input name="email" value={form.email} onChange={handleChange} required />
         </label>
         <label>
-          Password:
+          {t('password')}:
           <input type="password" name="password" value={form.password} onChange={handleChange} required />
         </label>
-        <button type="submit">Login</button>
+        <button type="submit">{t('login')}</button>
         {error && <div className="error">{error}</div>}
       </form>
       <p>
-        Don't have an account? <Link to="/register">Register</Link>
+        {t('dontHaveAccount')} <Link to="/register">{t('register')}</Link>
       </p>
     </div>
   );

--- a/3dFrontend/src/Pages/NotFoundPage.js
+++ b/3dFrontend/src/Pages/NotFoundPage.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
+import { useLanguage } from '../context/LanguageContext';
 
 function NotFoundPage() {
+  const { t } = useLanguage();
   return (
     <div style={{ padding: '2rem', textAlign: 'center' }}>
       <Helmet>
         <title>404 - Page Not Found - 3D Figures Store</title>
-        <meta name="description" content="The page you are looking for does not exist." />
+        <meta name="description" content={t('pageNotFoundMessage')} />
         <link rel="canonical" href={window.location.href} />
       </Helmet>
-      <h2>Page Not Found</h2>
-      <p>The page you are looking for does not exist.</p>
+      <h2>{t('pageNotFoundTitle')}</h2>
+      <p>{t('pageNotFoundMessage')}</p>
     </div>
   );
 }

--- a/3dFrontend/src/Pages/ProductDetailPage.js
+++ b/3dFrontend/src/Pages/ProductDetailPage.js
@@ -10,6 +10,7 @@ import ImageCarousel from '../Components/ImageCarousel';
 import '../styles/ProductDetailPage.css';
 import { useCart } from '../context/CartContext';
 import ClipLoader from 'react-spinners/ClipLoader';
+import { useLanguage } from '../context/LanguageContext';
 
 function ProductDetailPage() {
   const { id } = useParams();
@@ -19,6 +20,7 @@ function ProductDetailPage() {
   const [modelUrl, setModelUrl] = useState(null);
   const { addToCart } = useCart();
   const [qty, setQty] = useState(1);
+  const { t } = useLanguage();
 
   useEffect(() => {
     setLoading(true);
@@ -85,13 +87,13 @@ function ProductDetailPage() {
         <h2>{product.name}</h2>
         <p className="price">${parseFloat(product.selling_cost).toFixed(2)}</p>
         <ul className="specs">
-          <li>Height: {product.height} cm</li>
-          <li>Length: {product.length} cm</li>
-          <li>Depth: {product.depth} cm</li>
+          <li>{t('height')}: {product.height} cm</li>
+          <li>{t('length')}: {product.length} cm</li>
+          <li>{t('depth')}: {product.depth} cm</li>
         </ul>
         <div style={{ marginTop: 20 }}>
           <label htmlFor="quantity-input">
-            Quantity
+            {t('quantity')}
             <input
               id="quantity-input"
               type="number"
@@ -101,7 +103,7 @@ function ProductDetailPage() {
               style={{ width: 50 }}
             />
           </label>
-        <button onClick={() => addToCart(product, qty)}>Add to Cart</button>
+        <button onClick={() => addToCart(product, qty)}>{t('addToCart')}</button>
         </div>
       </div>
     </div>

--- a/3dFrontend/src/Pages/RegisterPage.js
+++ b/3dFrontend/src/Pages/RegisterPage.js
@@ -3,12 +3,14 @@ import { useNavigate, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import { useAuth } from '../context/AuthContext';
 import '../styles/AuthPage.css';
+import { useLanguage } from '../context/LanguageContext';
 
 function RegisterPage() {
   const { register } = useAuth();
   const navigate = useNavigate();
   const [form, setForm] = useState({ email: '', password: '' });
   const [error, setError] = useState('');
+  const { t } = useLanguage();
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -21,7 +23,7 @@ function RegisterPage() {
       await register(form.email, form.password);
       navigate('/');
     } catch (err) {
-      setError('Registration failed');
+      setError(t('registrationFailed'));
     }
   };
 
@@ -32,21 +34,21 @@ function RegisterPage() {
         <meta name="description" content="Create an account to purchase 3D figures." />
         <link rel="canonical" href={window.location.href} />
       </Helmet>
-      <h2>Register</h2>
+      <h2>{t('register')}</h2>
       <form onSubmit={handleSubmit}>
         <label>
-          Email:
+          {t('email')}:
           <input name="email" value={form.email} onChange={handleChange} required />
         </label>
         <label>
-          Password:
+          {t('password')}:
           <input type="password" name="password" value={form.password} onChange={handleChange} required />
         </label>
-        <button type="submit">Register</button>
+        <button type="submit">{t('register')}</button>
         {error && <div className="error">{error}</div>}
       </form>
       <p>
-        Already have an account? <Link to="/login">Login</Link>
+        {t('alreadyHaveAccount')} <Link to="/login">{t('login')}</Link>
       </p>
     </div>
   );

--- a/3dFrontend/src/context/LanguageContext.js
+++ b/3dFrontend/src/context/LanguageContext.js
@@ -1,0 +1,132 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const LanguageContext = createContext();
+
+const translations = {
+  en: {
+    products: 'Products',
+    cart: 'Cart',
+    hi: 'Hi',
+    logout: 'Logout',
+    login: 'Login',
+    register: 'Register',
+    lightMode: 'Light Mode',
+    darkMode: 'Dark Mode',
+    searchPlaceholder: 'Search...',
+    search: 'Search',
+    categories: 'Categories',
+    all: 'All',
+    welcome: 'Welcome to Our 3D Figures Store',
+    discover: 'Discover our collection of amazing 3D printed figures.',
+    shopNow: 'Shop Now',
+    featuredModels: 'Featured 3D Models',
+    experience: 'Experience our latest creation from every angle.',
+    exploreModels: 'Explore Models',
+    pageNotFoundTitle: 'Page Not Found',
+    pageNotFoundMessage: 'The page you are looking for does not exist.',
+    quantity: 'Quantity',
+    addToCart: 'Add to Cart',
+    height: 'Height',
+    length: 'Length',
+    depth: 'Depth',
+    yourCart: 'Your Cart',
+    cartEmpty: 'Your cart is empty.',
+    product: 'Product',
+    qty: 'Qty',
+    unitPrice: 'Unit Price',
+    subtotal: 'Subtotal',
+    remove: 'Remove',
+    total: 'Total',
+    proceedCheckout: 'Proceed to Checkout',
+    continueShopping: 'Continue Shopping',
+    checkout: 'Checkout',
+    email: 'Email',
+    address: 'Address',
+    orderSummary: 'Order Summary',
+    paypal: 'PayPal',
+    creditCard: 'Credit Card',
+    paymentSuccess: 'Payment successful!',
+    dontHaveAccount: "Don't have an account?",
+    alreadyHaveAccount: 'Already have an account?',
+    password: 'Password',
+    loginFailed: 'Login failed',
+    registrationFailed: 'Registration failed',
+    nameOnCard: 'Name on Card',
+    cardNumber: 'Card Number',
+    expiryDate: 'Expiry Date (MM/YY)',
+    cvc: 'CVC',
+    processing: 'Processing...',
+    payNow: 'Pay Now',
+    paymentFailed: 'Payment failed. Please try again.'
+  },
+  es: {
+    products: 'Productos',
+    cart: 'Carrito',
+    hi: 'Hola',
+    logout: 'Cerrar sesión',
+    login: 'Iniciar sesión',
+    register: 'Registrarse',
+    lightMode: 'Modo Claro',
+    darkMode: 'Modo Oscuro',
+    searchPlaceholder: 'Buscar...',
+    search: 'Buscar',
+    categories: 'Categorías',
+    all: 'Todos',
+    welcome: 'Bienvenido a Nuestra Tienda de Figuras 3D',
+    discover: 'Descubre nuestra colección de increíbles figuras impresas en 3D.',
+    shopNow: 'Comprar Ahora',
+    featuredModels: 'Modelos 3D Destacados',
+    experience: 'Experimenta nuestra última creación desde todos los ángulos.',
+    exploreModels: 'Explorar Modelos',
+    pageNotFoundTitle: 'Página No Encontrada',
+    pageNotFoundMessage: 'La página que buscas no existe.',
+    quantity: 'Cantidad',
+    addToCart: 'Añadir al Carrito',
+    height: 'Altura',
+    length: 'Largo',
+    depth: 'Profundidad',
+    yourCart: 'Tu Carrito',
+    cartEmpty: 'Tu carrito está vacío.',
+    product: 'Producto',
+    qty: 'Cant.',
+    unitPrice: 'Precio Unitario',
+    subtotal: 'Subtotal',
+    remove: 'Eliminar',
+    total: 'Total',
+    proceedCheckout: 'Proceder al Pago',
+    continueShopping: 'Seguir Comprando',
+    checkout: 'Pago',
+    email: 'Correo electrónico',
+    address: 'Dirección',
+    orderSummary: 'Resumen del Pedido',
+    paypal: 'PayPal',
+    creditCard: 'Tarjeta de Crédito',
+    paymentSuccess: '¡Pago exitoso!',
+    dontHaveAccount: '¿No tienes una cuenta?',
+    alreadyHaveAccount: '¿Ya tienes una cuenta?',
+    password: 'Contraseña',
+    loginFailed: 'Error al iniciar sesión',
+    registrationFailed: 'Error al registrarse',
+    nameOnCard: 'Nombre en la tarjeta',
+    cardNumber: 'Número de tarjeta',
+    expiryDate: 'Fecha de expiración (MM/AA)',
+    cvc: 'CVC',
+    processing: 'Procesando...',
+    payNow: 'Pagar ahora',
+    paymentFailed: 'Pago fallido. Por favor, inténtalo de nuevo.'
+  }
+};
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState('en');
+  const t = (key) => translations[language][key] || key;
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => useContext(LanguageContext);
+
+export default LanguageContext;

--- a/3dFrontend/src/index.js
+++ b/3dFrontend/src/index.js
@@ -9,17 +9,20 @@ import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import { CartProvider } from './context/CartContext';
 import { AuthProvider } from './context/AuthContext';
 import { ThemeProvider } from './context/ThemeContext';
+import { LanguageProvider } from './context/LanguageContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HelmetProvider>
-      <ThemeProvider>
-        <AuthProvider>
-          <CartProvider>
-            <App />
-          </CartProvider>
-        </AuthProvider>
-      </ThemeProvider>
+      <LanguageProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            <CartProvider>
+              <App />
+            </CartProvider>
+          </AuthProvider>
+        </ThemeProvider>
+      </LanguageProvider>
     </HelmetProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add LanguageContext with English and Spanish translations and provider
- allow language selection from header and translate UI text
- localize checkout and other pages

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689103927cc48325aca77a9a271b4d4d